### PR TITLE
Faster calc cost matrix

### DIFF
--- a/oc_cost/Annotations.py
+++ b/oc_cost/Annotations.py
@@ -7,18 +7,8 @@ class BBox:
         self.y = lefttop[1]
         self.width = width
         self.height = height
-
-    def get_lefttop(self):
-        return (self.x, self.y)
-
-    def get_rightbottom(self):
-        return (self.x + self.width, self.y + self.height)
-
-    def get_rightbottom_x(self):
-        return (self.x + self.width)
-
-    def get_rightbottom_y(self):
-        return (self.y + self.height)
+        self.x2 = self.x + self.width
+        self.y2 = self.y + self.height
 
 
 class predBBox(BBox):

--- a/oc_cost/Annotations.py
+++ b/oc_cost/Annotations.py
@@ -23,11 +23,7 @@ class BBox:
 
 class predBBox(BBox):
     def __init__(self, label, lefttop, width, height, precision):
-        self.label = label
-        self.x = lefttop[0]
-        self.y = lefttop[1]
-        self.width = width
-        self.height = height
+        super().__init__(label, lefttop, width, height)
         self.precision = precision
 
 

--- a/oc_cost/Annotations.py
+++ b/oc_cost/Annotations.py
@@ -9,6 +9,7 @@ class BBox:
         self.height = height
         self.x2 = self.x + self.width
         self.y2 = self.y + self.height
+        self.area = (width + 1) * (height + 1)
 
 
 class predBBox(BBox):

--- a/oc_cost/oc_cost.py
+++ b/oc_cost/oc_cost.py
@@ -13,10 +13,8 @@ class OC_Cost:
             self.mode = "iou"
 
     def getIntersectUnion(self, truth: BBox, pred: predBBox):
-        a_area = (truth.get_rightbottom_x() - truth.x + 1) * \
-            (truth.get_rightbottom_y() - truth.y + 1)
-        b_area = (pred.get_rightbottom_x() - pred.x + 1) * \
-            (pred.get_rightbottom_y() - pred.y + 1)
+        a_area = (truth.width + 1) * (truth.height + 1)
+        b_area = (pred.width + 1) * (pred.height + 1)
 
         w = max(0, self.__min_x2 - self.__max_x1 + 1)
         h = max(0, self.__min_y2 - self.__max_y1 + 1)

--- a/oc_cost/oc_cost.py
+++ b/oc_cost/oc_cost.py
@@ -48,7 +48,7 @@ class OC_Cost:
 
         intersect, union = self.getIntersectUnion(truth, pred)
 
-        iou = self.getIOU(truth, pred)
+        iou = intersect / (union)
         Giou = iou - ((c_area - union) / c_area)
 
         return Giou

--- a/oc_cost/oc_cost.py
+++ b/oc_cost/oc_cost.py
@@ -13,14 +13,11 @@ class OC_Cost:
             self.mode = "iou"
 
     def getIntersectUnion(self, truth: BBox, pred: predBBox):
-        a_area = (truth.width + 1) * (truth.height + 1)
-        b_area = (pred.width + 1) * (pred.height + 1)
-
         w = max(0, self.__min_x2 - self.__max_x1 + 1)
         h = max(0, self.__min_y2 - self.__max_y1 + 1)
         intersect = w * h
 
-        union = a_area + b_area - intersect
+        union = truth.area + pred.area - intersect
 
         return intersect, union
 

--- a/oc_cost/oc_cost.py
+++ b/oc_cost/oc_cost.py
@@ -18,12 +18,8 @@ class OC_Cost:
         b_area = (pred.get_rightbottom_x() - pred.x + 1) * \
             (pred.get_rightbottom_y() - pred.y + 1)
 
-        abx_mn = max(truth.x, pred.x)
-        aby_mn = max(truth.y, pred.y)
-        abx_mx = min(truth.get_rightbottom_x(), pred.get_rightbottom_x())
-        aby_mx = min(truth.get_rightbottom_y(), pred.get_rightbottom_y())
-        w = max(0, abx_mx - abx_mn + 1)
-        h = max(0, aby_mx - aby_mn + 1)
+        w = max(0, self.__min_x2 - self.__max_x1 + 1)
+        h = max(0, self.__min_y2 - self.__max_y1 + 1)
         intersect = w * h
 
         union = a_area + b_area - intersect
@@ -38,13 +34,8 @@ class OC_Cost:
         return iou
 
     def getGIOU(self, truth: BBox, pred: predBBox):
-
-        abx_mn = min(truth.x, pred.x)
-        aby_mn = min(truth.y, pred.y)
-        abx_mx = max(truth.get_rightbottom_x(), pred.get_rightbottom_x())
-        aby_mx = max(truth.get_rightbottom_y(), pred.get_rightbottom_y())
-
-        c_area = (abx_mx - abx_mn + 1) * (aby_mx - aby_mn + 1)
+        c_area = ((self.__max_x2 - self.__min_x1 + 1) *
+                  (self.__max_y2 - self.__min_y1 + 1))
 
         intersect, union = self.getIntersectUnion(truth, pred)
 
@@ -65,6 +56,33 @@ class OC_Cost:
             float: C_loc
         """
         cost: float = 0
+
+        # pre-calculate min max
+        if truth.x > pred.x:
+            self.__min_x1 = pred.x
+            self.__max_x1 = truth.x
+        else:
+            self.__min_x1 = truth.x
+            self.__max_x1 = pred.x
+        if truth.y > pred.y:
+            self.__min_y1 = pred.y
+            self.__max_y1 = truth.y
+        else:
+            self.__min_y1 = truth.y
+            self.__max_y1 = pred.y
+        if truth.get_rightbottom_x() > pred.get_rightbottom_x():
+            self.__min_x2 = pred.get_rightbottom_x()
+            self.__max_x2 = truth.get_rightbottom_x()
+        else:
+            self.__min_x2 = truth.get_rightbottom_x()
+            self.__max_x2 = pred.get_rightbottom_x()
+        if truth.get_rightbottom_y() > pred.get_rightbottom_y():
+            self.__min_y2 = pred.get_rightbottom_y()
+            self.__max_y2 = truth.get_rightbottom_y()
+        else:
+            self.__min_y2 = truth.get_rightbottom_y()
+            self.__max_y2 = pred.get_rightbottom_y()
+
         if self.mode == "giou":
             cost = (1 - self.getGIOU(truth, pred)) / 2
         if self.mode == "iou":

--- a/oc_cost/oc_cost.py
+++ b/oc_cost/oc_cost.py
@@ -68,18 +68,18 @@ class OC_Cost:
         else:
             self.__min_y1 = truth.y
             self.__max_y1 = pred.y
-        if truth.get_rightbottom_x() > pred.get_rightbottom_x():
-            self.__min_x2 = pred.get_rightbottom_x()
-            self.__max_x2 = truth.get_rightbottom_x()
+        if truth.x2 > pred.x2:
+            self.__min_x2 = pred.x2
+            self.__max_x2 = truth.x2
         else:
-            self.__min_x2 = truth.get_rightbottom_x()
-            self.__max_x2 = pred.get_rightbottom_x()
-        if truth.get_rightbottom_y() > pred.get_rightbottom_y():
-            self.__min_y2 = pred.get_rightbottom_y()
-            self.__max_y2 = truth.get_rightbottom_y()
+            self.__min_x2 = truth.x2
+            self.__max_x2 = pred.x2
+        if truth.y2 > pred.y2:
+            self.__min_y2 = pred.y2
+            self.__max_y2 = truth.y2
         else:
-            self.__min_y2 = truth.get_rightbottom_y()
-            self.__max_y2 = pred.get_rightbottom_y()
+            self.__min_y2 = truth.y2
+            self.__max_y2 = pred.y2
 
         if self.mode == "giou":
             cost = (1 - self.getGIOU(truth, pred)) / 2


### PR DESCRIPTION
- `build_C_matrix` processing 4 times faster in demo.py.
  - 146.673 sec -> 37.823 sec (in my environment)
- total processing 17% faster in demo.py.
  - 698.258 sec -> 577.944 sec (in my environment)

